### PR TITLE
A few simple general enhancements for better settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 const { Plugin } = require("powercord/entities");
 const { inject, uninject } = require("powercord/injector");
-const {getModule} = require('powercord/webpack');
+const { getModule, i18n: { Messages } } = require('powercord/webpack');
 module.exports = class BetterSettings extends Plugin {
   async startPlugin() {
     const pluginsettings = require('./settings');
@@ -28,7 +28,7 @@ module.exports = class BetterSettings extends Plugin {
       settingsicon.setAttributeNode(iconclass)
       settingsclass.value = "settingssearch";
       settingsid.value = "settingssearch";
-      placeholder.value = "Search"
+      placeholder.value = Messages.SEARCH;
       check.value = "checked"
       searchdivclass.value = "searchdiv"
       searchdiv.setAttributeNode(searchdivclass)
@@ -69,7 +69,7 @@ module.exports = class BetterSettings extends Plugin {
               noresults = document.createElement("div")
               noresultsclass = document.createAttribute("class")
               noresultsclass.value = "noresults"
-              noresults.textContent = "We searched far and wide. Unfortunately, no results were found."
+              noresults.textContent = Messages.SEARCH_NO_RESULTS;
               noresults.setAttributeNode(noresultsclass)
               settings.appendChild(noresults)
               }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = class BetterSettings extends Plugin {
       settingsbar.setAttributeNode(settingsclass);
       settingsbar.setAttributeNode(settingsid);
       settingsbar.setAttributeNode(placeholder);
-      settings.appendChild(searchdiv);
+      settings.prepend(searchdiv);
       searchdiv.appendChild(settingsbar)
       settings.setAttributeNode(check)
       searchdiv.appendChild(settingsicon)

--- a/index.scss
+++ b/index.scss
@@ -79,7 +79,8 @@
     color: white;
     // display: none;
 }
-.noresults{
+.noresults {
+	margin: auto;
     margin-top: 10px;
     grid-area: 2/1;
     height: 182px;


### PR DESCRIPTION
- Adds some basic i18n support (search placeholder and no results text now have translations, taken from built-in Discord i18n vars)
- Centers the no results message as some themes make the settings sidebar wider
- Places the searchbox as the first element in the settings sidebar in the DOM, avoiding `positon: absolute;`