### PR TITLE
styling changes in quick action buttons

### DIFF
--- a/components/QuickActions.jsx
+++ b/components/QuickActions.jsx
@@ -2,7 +2,7 @@
 const { React } = require("powercord/webpack");
 const {
   Tooltip,
-  Icons: { GitHub, Bin, Sync, Person },
+  Icons: { GitHub, Bin, Sync, Discord },
 } = require("powercord/components");
 
 const { shell } = require("electron");
@@ -45,7 +45,7 @@ module.exports = ({ url, pluginpath, server, id }) => {
       {server != "none" ? (
         <Tooltip text="Support Server">
           <a id="better-settings-server" href={server} target="_blank">
-            <Person />
+            <Discord />
           </a>
         </Tooltip>
       ) : null}

--- a/index.scss
+++ b/index.scss
@@ -237,7 +237,7 @@
   display: block;
   color: white;
   padding: 0px;
-  margin: 7px 6px 4px 6px;
+  margin: 7px 6px 4px 0px;
   svg {
     height: 25px;
     width: 25px;


### PR DESCRIPTION
Namely makes the margins a little more consistent and uses the discord icon instead of the person one for discord server links